### PR TITLE
feat: Add stopAndCleanupSession function to handle stopping mining sessions

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -28,7 +28,8 @@ type LootItem struct {
 type DropTable []LootItem
 
 type Player struct {
-	ID        string          `bson:"_id" json:"id"`
-	Username  string          `bson:"username" json:"username"`
-	Inventory []InventoryItem `bson:"inventory" json:"inventory"`
+	ID        string             `bson:"_id" json:"id"`
+	Username  string             `bson:"username" json:"username"`
+	Inventory []InventoryItem    `bson:"inventory" json:"inventory"`
+	Skills    map[string]float64 `bson:"skills" json:"skills"`
 }

--- a/internal/skills/mining/session.go
+++ b/internal/skills/mining/session.go
@@ -1,6 +1,7 @@
 package mining
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -8,6 +9,10 @@ import (
 	"rs3/internal/model"
 	"rs3/internal/players"
 	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 const SWING_TIME = 2400 * time.Millisecond
@@ -15,11 +20,15 @@ const SWING_TIME = 2400 * time.Millisecond
 type MiningSession struct {
 	Rock       *Rock
 	Player     *model.Player
+	Client     *mongo.Client
+	Context    context.Context
 	SendMsg    func(msg []byte)
 	StopSignal chan bool // Used to signal when the mining session should stop
 }
 
 func (ms *MiningSession) Start() {
+	var accumulatedXP float64 = 0
+
 	level := int32(1)
 	pickaxe := players.FindHighestLevelPickaxe(ms.Player)
 	initialRockHealth := ms.Rock.Durability
@@ -28,38 +37,60 @@ func (ms *MiningSession) Start() {
 		ticker := time.NewTicker(SWING_TIME)
 		defer ticker.Stop()
 
-		for range ticker.C {
-			if pickaxe == nil {
-				ms.sendProgressMessage("error", "You don't have a pickaxe equipped", 0, 0, 0)
+		for {
+			select {
+			case <-ticker.C:
+				if pickaxe == nil {
+					ms.sendProgressMessage("error", "You don't have a pickaxe equipped", 0, 0, 0)
+					return
+				}
+
+				pickaxeProps, isValidPickaxe := pickaxe.Item.Properties.(items.PickaxeProperties)
+				if !isValidPickaxe {
+					ms.sendProgressMessage("error", "Item used to mine the rock is not a pickaxe", 0, 0, 0)
+					return
+				}
+
+				netHardness := int32(pickaxeProps.Penetration) - int32(ms.Rock.Hardness)
+				damageRoll := pickaxeProps.CalculateDamageRoll()
+				damage := int32(level) + damageRoll + netHardness
+
+				// Ensure the last hit is the remaining Durability (don't go below 0)
+				if (ms.Rock.Durability - damage) < 0 {
+					damage = ms.Rock.Durability
+				}
+
+				// Calculate the experience gained
+				xp := ms.Rock.calculateExperience(damage)
+				accumulatedXP += xp
+
+				// Damage the rock
+				ms.Rock.Durability -= damage
+				progress := (float32(initialRockHealth-ms.Rock.Durability) / float32(initialRockHealth)) * 100
+
+				ms.sendProgressMessage("swinging", fmt.Sprintf("You mine the rock and deal %v damage.", damage), progress, damage, xp)
+
+				if ms.Rock.Durability <= 0 {
+					// Update the player's skill XP in MongoDB
+					ms.updatePlayerSkillXP(accumulatedXP)
+					accumulatedXP = 0
+
+					// Reset the rock health
+					ms.Rock.Durability = initialRockHealth
+					continue
+				}
+
+			case <-ms.StopSignal:
+				// Clean-up logic here
+				log.Println("Stopping mining session for player", ms.Player.ID)
+
+				// Update the player's skill XP in MongoDB
+				ms.updatePlayerSkillXP(accumulatedXP)
+				accumulatedXP = 0
+
+				// Stop the Ticker
+				ticker.Stop()
 				return
-			}
-
-			pickaxeProps, isValidPickaxe := pickaxe.Item.Properties.(items.PickaxeProperties)
-			if !isValidPickaxe {
-				ms.sendProgressMessage("error", "Item used to mine the rock is not a pickaxe", 0, 0, 0)
-				return
-			}
-
-			netHardness := int32(pickaxeProps.Penetration) - int32(ms.Rock.Hardness)
-			damageRoll := pickaxeProps.CalculateDamageRoll()
-			damage := int32(level) + damageRoll + netHardness
-
-			// Ensure the last hit is the remaining Durability (don't go below 0)
-			if (ms.Rock.Durability - damage) < 0 {
-				damage = ms.Rock.Durability
-			}
-
-			// Calculate the experience gained
-			xp := ms.Rock.calculateExperience(damage)
-
-			ms.Rock.Durability -= damage
-			progress := (float32(initialRockHealth-ms.Rock.Durability) / float32(initialRockHealth)) * 100
-
-			ms.sendProgressMessage("swinging", fmt.Sprintf("You mine the rock and deal %v damage.", damage), progress, damage, xp)
-
-			if ms.Rock.Durability <= 0 {
-				ms.Rock.Durability = initialRockHealth
-				continue
 			}
 		}
 	}()
@@ -81,4 +112,16 @@ func (ms *MiningSession) sendProgressMessage(status, message string, progress fl
 		return
 	}
 	ms.SendMsg(progressJSON)
+}
+
+func (ms *MiningSession) updatePlayerSkillXP(xp float64) {
+	playerCollection := ms.Client.Database("rs3").Collection("players")
+	id, _ := primitive.ObjectIDFromHex(ms.Player.ID)
+	filter := bson.M{"_id": id}
+	update := bson.M{"$inc": bson.M{"skills.mining": xp}}
+
+	_, err := playerCollection.UpdateOne(ms.Context, filter, update)
+	if err != nil {
+		log.Printf("Failed to update player skill XP: %v\n", err)
+	}
 }


### PR DESCRIPTION
- Created a new function stopAndCleanupSession to handle stopping and cleaning up mining sessions for specific players. This function will send a stop signal to the active mining session for the player and remove the session from the active sessions map if it exists. If no active session is found, a log message will be printed indicating the same.

- Moved the declaration of activeMiningSessions to use mining.MiningSession instead of a boolean, for better tracking and management of active mining sessions.

- Updated WebSocket read error log message to include WebSocket disconnection information and call stopAndCleanupSession function to handle stopping and cleaning up the mining session for the disconnected player.

- Added a case for "stopMining" action in the WebSocket message handling to call the stopAndCleanupSession function for the corresponding player ID and clean up the mining session.

- Accumulated experience variable initialized in MiningSession Start function to track total experience gained during mining session. Updated the mining session logic to calculate and accumulate experience points while mining the rock. Improved progress messaging to include damage dealt, progress percentage, and experience gained during each swing.