### PR TITLE
feat: Add check to prevent starting a new mining session if there is already an active session for the player

### DIFF
--- a/cmd/rs3/main.go
+++ b/cmd/rs3/main.go
@@ -79,6 +79,13 @@ func main() {
 
 			switch req.Action {
 			case "startMining":
+				// Check if there's already an active session for this player
+				if _, exists := activeMiningSessions[player.ID]; exists {
+					log.Println("Mining session is already active, cannot start a new one.")
+					// Skip starting a new session
+					continue
+				}
+
 				rock, err := mining.GetRockById(c, client, req.RockId)
 				if err != nil {
 					// Send error message back via WebSocket


### PR DESCRIPTION
Added a check in the main function to prevent starting a new mining session if there is already an active session for the player. This prevents duplicate sessions from being started and helps improve the efficiency of the mining feature.